### PR TITLE
Add basic landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# HelloAsso2Kalisport
+
+Ce projet permet de relier les inscriptions HelloAsso au logiciel Kalisport. Il se compose d'un backend Axum et d'un frontend Yew.
+
+## Lancer le projet en mode développement
+
+```
+# Compilation du backend
+cargo run -p backend
+
+# Dans un autre terminal, compilation du frontend avec Trunk
+trunk serve --open
+```
+
+La page d'accueil s'affichera alors sur `http://localhost:8080` pour le backend et `http://localhost:8080` (ou port utilisé par Trunk) pour le frontend.

--- a/frontend/src/frontend.rs
+++ b/frontend/src/frontend.rs
@@ -3,8 +3,10 @@ use yew::prelude::*;
 #[function_component(App)]
 pub fn app() -> Html {
     html! {
-        <div>
-            { "Bienvenue sur HelloAsso2Kalisport !" }
+        <div class="container">
+            <h1>{ "HelloAsso2Kalisport" }</h1>
+            <p>{ "Bienvenue ! Cette application vous permettra d'exporter vos inscriptions HelloAsso vers Kalisport." }</p>
+            <button>{ "Commencer" }</button>
         </div>
     }
 }

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+}
+
+.container {
+    max-width: 600px;
+    margin: 50px auto;
+    text-align: center;
+}
+
+button {
+    padding: 10px 20px;
+    font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- create README with basic dev instructions
- add simple Yew landing page with button
- include minimal stylesheet

## Testing
- `cargo check -p backend` *(fails: failed to download crates)*
- `cargo check -p frontend` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68793aa56984832dbeb5d263f1e6921c