### PR TITLE
Add fallback content to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# HelloAsso2Kalisport
+
+Ce projet permet de relier les inscriptions HelloAsso au logiciel Kalisport. Il se compose d'un backend Axum et d'un frontend Yew.
+
+## Lancer le projet en mode développement
+
+```
+# Compilation du backend
+cargo run -p backend
+
+# Dans un autre terminal, compilation du frontend avec Trunk
+trunk serve --open
+```
+
+La page d'accueil s'affichera alors sur `http://localhost:8080` pour le backend et `http://localhost:8080` (ou port utilisé par Trunk) pour le frontend.

--- a/frontend/src/frontend.rs
+++ b/frontend/src/frontend.rs
@@ -3,8 +3,10 @@ use yew::prelude::*;
 #[function_component(App)]
 pub fn app() -> Html {
     html! {
-        <div>
-            { "Bienvenue sur HelloAsso2Kalisport !" }
+        <div class="container">
+            <h1>{ "HelloAsso2Kalisport" }</h1>
+            <p>{ "Bienvenue ! Cette application vous permettra d'exporter vos inscriptions HelloAsso vers Kalisport." }</p>
+            <button>{ "Commencer" }</button>
         </div>
     }
 }

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -7,7 +7,15 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main id="root"></main>
+    <noscript>
+      <div class="container">
+        <h1>HelloAsso2Kalisport</h1>
+        <p>Cette application nécessite JavaScript pour fonctionner.</p>
+      </div>
+    </noscript>
+    <main id="root">
+      <p>Chargement…</p>
+    </main>
     <script type="module">
       import init from './frontend.js';
       init();

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+}
+
+.container {
+    max-width: 600px;
+    margin: 50px auto;
+    text-align: center;
+}
+
+button {
+    padding: 10px 20px;
+    font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- update frontend/static/index.html with a loading message and noscript notice

## Testing
- `cargo check -p backend` *(fails: use of undeclared type `Server`)*
- `cargo check -p frontend`
- `cargo clippy -p backend` *(fails: use of undeclared type `Server`)*
- `cargo clippy -p frontend`


------
https://chatgpt.com/codex/tasks/task_e_68793aa56984832dbeb5d263f1e6921c