### PR TITLE
Add adhesion listing page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,9 @@ dependencies = [
  "shared",
  "stylist",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-logger",
+ "web-sys",
  "yew",
  "yew-router",
 ]

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -1,16 +1,54 @@
-use axum::{Router, http::Method};
-use tokio::net::TcpListener;
+use axum::{Json, Router, extract::State, http::Method, routing::get};
+use chrono::NaiveDate;
+use shared::Adherent;
+use std::sync::Arc;
+use tokio::{net::TcpListener, sync::RwLock};
 use tower_cookies::CookieManagerLayer;
 use tower_http::cors::{Any, CorsLayer};
 
+#[derive(Default)]
+pub struct AppState {
+    pub adhesions: RwLock<Vec<Adherent>>,
+}
+
+async fn list_adhesions(State(state): State<Arc<AppState>>) -> Json<Vec<Adherent>> {
+    let adhesions = state.adhesions.read().await.clone();
+    Json(adhesions)
+}
+
+fn example_adhesions() -> Vec<Adherent> {
+    vec![
+        Adherent {
+            nom: "Doe".into(),
+            prenom: "John".into(),
+            date_naissance: NaiveDate::from_ymd_opt(1990, 1, 1).unwrap(),
+            email: "john.doe@example.com".into(),
+            deja_exporte: false,
+        },
+        Adherent {
+            nom: "Dupont".into(),
+            prenom: "Jeanne".into(),
+            date_naissance: NaiveDate::from_ymd_opt(1985, 5, 12).unwrap(),
+            email: "jeanne.dupont@example.com".into(),
+            deja_exporte: false,
+        },
+    ]
+}
+
 pub async fn run() {
-    let app = Router::new().layer(CookieManagerLayer::new()).layer(
-        CorsLayer::new().allow_origin(Any).allow_methods([
+    let state = Arc::new(AppState {
+        adhesions: RwLock::new(example_adhesions()),
+    });
+
+    let app = Router::new()
+        .route("/api/adhesions", get(list_adhesions))
+        .with_state(state)
+        .layer(CookieManagerLayer::new())
+        .layer(CorsLayer::new().allow_origin(Any).allow_methods([
             Method::GET,
             Method::POST,
             Method::OPTIONS,
-        ]),
-    );
+        ]));
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 8080));
     println!("Serveur backend lancé sur http://{}", addr);
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -17,3 +17,5 @@ chrono = { version = "0.4.38", default-features = false, features = ["serde"] }
 shared = { path = "../shared" }
 wasm-bindgen = "0.2.92"
 wasm-logger = "0.2.0"
+wasm-bindgen-futures = "0.4.50"
+web-sys = { version = "0.3.77", features = ["MouseEvent"] }

--- a/frontend/src/pages/hello_asso.rs
+++ b/frontend/src/pages/hello_asso.rs
@@ -1,11 +1,48 @@
+use gloo_net::http::Request;
+use shared::Adherent;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::MouseEvent;
 use yew::prelude::*;
 
-/// Simple page placeholder for the HelloAsso part of the application
+/// Page listing all memberships with a refresh button
 #[function_component(HelloAssoPage)]
 pub fn hello_asso_page() -> Html {
+    let adhesions = use_state(Vec::<Adherent>::new);
+
+    let fetch_adhesions = move |state: UseStateHandle<Vec<Adherent>>| {
+        spawn_local(async move {
+            if let Ok(resp) = Request::get("/api/adhesions").send().await {
+                if let Ok(data) = resp.json::<Vec<Adherent>>().await {
+                    state.set(data);
+                }
+            }
+        });
+    };
+
+    let load = {
+        let adhesions = adhesions.clone();
+        Callback::from(move |_e: MouseEvent| {
+            fetch_adhesions(adhesions.clone());
+        })
+    };
+
+    {
+        let adhesions = adhesions.clone();
+        use_effect(move || {
+            fetch_adhesions(adhesions);
+            || ()
+        });
+    }
+
     html! {
         <div class="container">
-            <h1>{ "Page HelloAsso" }</h1>
+            <h1>{ "Adhésions" }</h1>
+            <button onclick={load.clone()}>{ "Rafraîchir" }</button>
+            <ul>
+                { for adhesions.iter().map(|a| html!{
+                    <li>{ format!("{} {} - {}", a.prenom, a.nom, a.email) }</li>
+                }) }
+            </ul>
         </div>
     }
 }


### PR DESCRIPTION
## Summary
- implement backend in-memory adhesions API
- create HelloAsso page displaying adhesions with refresh
- add web-sys and wasm-bindgen-futures dependencies

## Testing
- `cargo clippy -- -D warnings`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687b972863ac832d9e45f7170a21fc8c