### PR TITLE
Add season list and detail pages

### DIFF
--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -1,13 +1,14 @@
 use yew::prelude::*;
 use yew_router::prelude::*;
 
-use crate::pages::{HelloAssoPage, Home};
+use crate::pages::{HelloAssoPage, Home, SaisonPage};
 use crate::routes::Route;
 
 fn switch(route: Route) -> Html {
     match route {
         Route::Home => html! { <Home /> },
         Route::HelloAsso => html! { <HelloAssoPage /> },
+        Route::Saison { id } => html! { <SaisonPage saison_id={id} /> },
     }
 }
 

--- a/frontend/src/pages/hello_asso.rs
+++ b/frontend/src/pages/hello_asso.rs
@@ -1,18 +1,20 @@
+use crate::routes::Route;
 use gloo_net::http::Request;
-use shared::Adherent;
+use shared::Saison;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::MouseEvent;
 use yew::prelude::*;
+use yew_router::prelude::Link;
 
 /// Page listing all memberships with a refresh button
 #[function_component(HelloAssoPage)]
 pub fn hello_asso_page() -> Html {
-    let adhesions = use_state(Vec::<Adherent>::new);
+    let saisons = use_state(Vec::<Saison>::new);
 
-    let fetch_adhesions = move |state: UseStateHandle<Vec<Adherent>>| {
+    let fetch_saisons = move |state: UseStateHandle<Vec<Saison>>| {
         spawn_local(async move {
-            if let Ok(resp) = Request::get("/api/adhesions").send().await {
-                if let Ok(data) = resp.json::<Vec<Adherent>>().await {
+            if let Ok(resp) = Request::get("/api/saisons").send().await {
+                if let Ok(data) = resp.json::<Vec<Saison>>().await {
                     state.set(data);
                 }
             }
@@ -20,16 +22,16 @@ pub fn hello_asso_page() -> Html {
     };
 
     let load = {
-        let adhesions = adhesions.clone();
+        let saisons = saisons.clone();
         Callback::from(move |_e: MouseEvent| {
-            fetch_adhesions(adhesions.clone());
+            fetch_saisons(saisons.clone());
         })
     };
 
     {
-        let adhesions = adhesions.clone();
+        let saisons = saisons.clone();
         use_effect(move || {
-            fetch_adhesions(adhesions);
+            fetch_saisons(saisons);
             || ()
         });
     }
@@ -39,8 +41,12 @@ pub fn hello_asso_page() -> Html {
             <h1>{ "Adhésions" }</h1>
             <button onclick={load.clone()}>{ "Rafraîchir" }</button>
             <ul>
-                { for adhesions.iter().map(|a| html!{
-                    <li>{ format!("{} {} - {}", a.prenom, a.nom, a.email) }</li>
+                { for saisons.iter().map(|s| html!{
+                    <li>
+                        <Link<Route> to={Route::Saison { id: s.id }}>
+                            { &s.nom }
+                        </Link<Route>>
+                    </li>
                 }) }
             </ul>
         </div>

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,6 +1,7 @@
-pub mod home;
 pub mod hello_asso;
+pub mod home;
+pub mod saison;
 
-pub use home::Home;
 pub use hello_asso::HelloAssoPage;
-
+pub use home::Home;
+pub use saison::SaisonPage;

--- a/frontend/src/pages/saison.rs
+++ b/frontend/src/pages/saison.rs
@@ -1,0 +1,63 @@
+use gloo_net::http::Request;
+use shared::Adherent;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::MouseEvent;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct SaisonPageProps {
+    pub saison_id: u32,
+}
+
+#[function_component(SaisonPage)]
+pub fn saison_page(props: &SaisonPageProps) -> Html {
+    let adherents = use_state(Vec::<Adherent>::new);
+
+    {
+        let adherents = adherents.clone();
+        let id = props.saison_id;
+        use_effect_with(id, move |_| {
+            spawn_local(async move {
+                if let Ok(resp) = Request::get(&format!("/api/saisons/{}/adhesions", id))
+                    .send()
+                    .await
+                {
+                    if let Ok(data) = resp.json::<Vec<Adherent>>().await {
+                        adherents.set(data);
+                    }
+                }
+            });
+            || ()
+        });
+    }
+
+    let onclick = {
+        let adherents = adherents.clone();
+        let id = props.saison_id;
+        Callback::from(move |_e: MouseEvent| {
+            let adherents = adherents.clone();
+            spawn_local(async move {
+                if let Ok(resp) = Request::get(&format!("/api/saisons/{}/adhesions", id))
+                    .send()
+                    .await
+                {
+                    if let Ok(data) = resp.json::<Vec<Adherent>>().await {
+                        adherents.set(data);
+                    }
+                }
+            });
+        })
+    };
+
+    html! {
+        <div class="container">
+            <h1>{ format!("Inscriptions saison {}", props.saison_id) }</h1>
+            <button {onclick}>{ "Rafraîchir" }</button>
+            <ul>
+                { for adherents.iter().map(|a| html!{
+                    <li>{ format!("{} {} - {}", a.prenom, a.nom, a.email) }</li>
+                }) }
+            </ul>
+        </div>
+    }
+}

--- a/frontend/src/routes.rs
+++ b/frontend/src/routes.rs
@@ -6,4 +6,6 @@ pub enum Route {
     Home,
     #[at("/helloasso")]
     HelloAsso,
+    #[at("/saison/:id")]
+    Saison { id: u32 },
 }

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -10,3 +10,9 @@ pub struct Adherent {
     // autres champs selon HelloAsso/Kalisport
     pub deja_exporte: bool,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Saison {
+    pub id: u32,
+    pub nom: String,
+}


### PR DESCRIPTION
## Summary
- introduce `Saison` model shared between backend and frontend
- return example seasons and members from new endpoints
- add frontend routing for seasons
- list seasons and allow viewing members of each season

## Testing
- `cargo check`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_687baab9ca14832d90a3fd0f87a39848