### PR TITLE
Improve dev port docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@ Ce projet permet de relier les inscriptions HelloAsso au logiciel Kalisport. Il 
 
 ## Lancer le projet en mode développement
 
-```
-# Compilation du backend
+Le serveur backend écoute sur le **port 8080**. Deux stratégies sont possibles pour le frontend :
+
+1. Lancer le backend en premier puis exécuter `trunk serve --open`. Trunk détectera que le port 8080 est pris et se lancera automatiquement sur `http://localhost:8081`.
+2. Ou spécifier directement un port libre pour Trunk :
+
+```bash
+# Backend sur http://localhost:8080
 cargo run -p backend
 
-# Dans un autre terminal, compilation du frontend avec Trunk
-trunk serve --open
+# Frontend sur un autre port, par exemple 8081
+trunk serve --port 8081 --open
 ```
 
-La page d'accueil s'affichera alors sur `http://localhost:8080` pour le backend et `http://localhost:8080` (ou port utilisé par Trunk) pour le frontend.
+Dans les deux cas, le backend sera accessible sur `http://localhost:8080` et le frontend sur `http://localhost:8081` (ou le port choisi par Trunk).


### PR DESCRIPTION
## Summary
- document backend port
- show how to run frontend on a different port

## Testing
- `cargo check`
- `cargo clippy`

------
https://chatgpt.com/codex/tasks/task_e_687bb0b51ebc832d9b3f71e0f80fc867