### PR TITLE
Make backend port configurable via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ trunk serve --open
 ```
 
 La page d'accueil s'affichera alors sur `http://localhost:8080` pour le backend et `http://localhost:8080` (ou port utilisé par Trunk) pour le frontend.
+
+Le port du backend peut être configuré en définissant la variable d'environnement `PORT`. Par défaut, il utilise le port `8080`.

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -98,7 +98,11 @@ pub async fn run() {
             Method::POST,
             Method::OPTIONS,
         ]));
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 8080));
+    let port = std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(8080);
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
     println!("Serveur backend lancé sur http://{}", addr);
 
     let listener = TcpListener::bind(addr).await.unwrap();


### PR DESCRIPTION
## Summary
- read the `PORT` environment variable when creating the backend socket address
- mention the variable in the README

## Testing
- `cargo check`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_687bb0ba7880832d830fe18f1d7dcc46