### PR TITLE
Add Trunk config and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ cargo run -p backend
 trunk serve --open
 ```
 
-La page d'accueil s'affichera alors sur `http://localhost:8080` pour le backend et `http://localhost:8080` (ou port utilisé par Trunk) pour le frontend.
+Le backend fonctionne sur `http://localhost:8080`. Le frontend est servi sur `http://localhost:8081` grâce au fichier `frontend/Trunk.toml` qui configure également un proxy des requêtes `/api` vers le backend.

--- a/frontend/Trunk.toml
+++ b/frontend/Trunk.toml
@@ -1,0 +1,3 @@
+[serve]
+port = 8081
+proxy.backend = "http://127.0.0.1:8080/api"


### PR DESCRIPTION
## Summary
- configure Trunk for the frontend
- document development server proxy and port

## Testing
- `cargo check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb0c49fd4832db0d243e0c9ecc868