### PR TITLE
Refactor API response handling

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -99,7 +99,7 @@ pub async fn run() {
             Method::OPTIONS,
         ]));
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 8080));
-    println!("Serveur backend lancé sur http://{}", addr);
+    println!("Serveur backend lancé sur http://{addr}");
 
     let listener = TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();

--- a/frontend/src/pages/hello_asso.rs
+++ b/frontend/src/pages/hello_asso.rs
@@ -13,10 +13,13 @@ pub fn hello_asso_page() -> Html {
 
     let fetch_saisons = move |state: UseStateHandle<Vec<Saison>>| {
         spawn_local(async move {
-            if let Ok(resp) = Request::get("/api/saisons").send().await {
-                if let Ok(data) = resp.json::<Vec<Saison>>().await {
-                    state.set(data);
-                }
+            if let Ok(data) = async {
+                let resp = Request::get("/api/saisons").send().await?;
+                resp.json::<Vec<Saison>>().await
+            }
+            .await
+            {
+                state.set(data);
             }
         });
     };

--- a/frontend/src/pages/saison.rs
+++ b/frontend/src/pages/saison.rs
@@ -18,13 +18,15 @@ pub fn saison_page(props: &SaisonPageProps) -> Html {
         let id = props.saison_id;
         use_effect_with(id, move |_| {
             spawn_local(async move {
-                if let Ok(resp) = Request::get(&format!("/api/saisons/{}/adhesions", id))
-                    .send()
-                    .await
+                if let Ok(data) = async {
+                    let resp = Request::get(&format!("/api/saisons/{id}/adhesions"))
+                        .send()
+                        .await?;
+                    resp.json::<Vec<Adherent>>().await
+                }
+                .await
                 {
-                    if let Ok(data) = resp.json::<Vec<Adherent>>().await {
-                        adherents.set(data);
-                    }
+                    adherents.set(data);
                 }
             });
             || ()
@@ -37,13 +39,15 @@ pub fn saison_page(props: &SaisonPageProps) -> Html {
         Callback::from(move |_e: MouseEvent| {
             let adherents = adherents.clone();
             spawn_local(async move {
-                if let Ok(resp) = Request::get(&format!("/api/saisons/{}/adhesions", id))
-                    .send()
-                    .await
+                if let Ok(data) = async {
+                    let resp = Request::get(&format!("/api/saisons/{id}/adhesions"))
+                        .send()
+                        .await?;
+                    resp.json::<Vec<Adherent>>().await
+                }
+                .await
                 {
-                    if let Ok(data) = resp.json::<Vec<Adherent>>().await {
-                        adherents.set(data);
-                    }
+                    adherents.set(data);
                 }
             });
         })


### PR DESCRIPTION
## Summary
- adjust backend log message for interpolated URL
- collapse nested `if` when loading seasons
- collapse nested `if` in saison page and reuse formatted path

## Testing
- `cargo clippy --workspace --all-targets --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687bbcccc0b0832dbd403f08afb230e9